### PR TITLE
Rename `symbolize` to `symbolize_keys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ require 'key_flatten/core_ext'
 ### Symbolize keys
 
 ```rb
-{"foo" => {"bar" => "baz"}}.key_flatten(symbolize: "_")
+{"foo" => {"bar" => "baz"}}.key_flatten(symbolize_keys: "_")
 # => {:"foo.bar" => "baz"}
 ```
 

--- a/lib/key_flatten.rb
+++ b/lib/key_flatten.rb
@@ -1,13 +1,13 @@
 require "key_flatten/version"
 
 module KeyFlatten
-  def self.key_flatten(hash, symbolize: false, delimiter: '.', prefix: nil, result: {})
+  def self.key_flatten(hash, symbolize_keys: false, delimiter: '.', prefix: nil, result: {})
     hash.each do |k, v|
       flat_key = prefix.nil? ? k.to_s : "#{prefix}#{delimiter}#{k}"
-      flat_key = symbolize ? flat_key.to_sym : flat_key.to_s
+      flat_key = symbolize_keys ? flat_key.to_sym : flat_key.to_s
 
       if v.is_a?(Hash)
-        self.key_flatten(v, symbolize: symbolize, delimiter: delimiter, prefix: flat_key, result: result)
+        self.key_flatten(v, symbolize_keys: symbolize_keys, delimiter: delimiter, prefix: flat_key, result: result)
       else
         result[flat_key] = v
       end
@@ -16,7 +16,7 @@ module KeyFlatten
     result
   end
 
-  def key_flatten(symbolize: false, delimiter: '.', prefix: nil)
-    ::KeyFlatten.key_flatten(self, symbolize: symbolize, delimiter: delimiter, prefix: prefix)
+  def key_flatten(symbolize_keys: false, delimiter: '.', prefix: nil)
+    ::KeyFlatten.key_flatten(self, symbolize_keys: symbolize_keys, delimiter: delimiter, prefix: prefix)
   end
 end

--- a/spec/key_flatten/core_ext_spec.rb
+++ b/spec/key_flatten/core_ext_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe KeyFlatten do
       end
     end
 
-    context 'when symbolize: true' do
+    context 'when symbolize_keys: true' do
       it 'flattens keys of Hash and the key is Symbol' do
-        expect({foo: 'bar'}.key_flatten(symbolize: true)).to eq({foo: 'bar'})
-        expect({foo: {bar: 'baz'}}.key_flatten(symbolize: true)).to eq({:'foo.bar' => 'baz'})
+        expect({foo: 'bar'}.key_flatten(symbolize_keys: true)).to eq({foo: 'bar'})
+        expect({foo: {bar: 'baz'}}.key_flatten(symbolize_keys: true)).to eq({:'foo.bar' => 'baz'})
       end
     end
 

--- a/spec/key_flatten_spec.rb
+++ b/spec/key_flatten_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe KeyFlatten do
       end
     end
 
-    context 'when symbolize: true' do
+    context 'when symbolize_keys: true' do
       it 'flattens keys of Hash and the key is Symbol' do
-        expect(KeyFlatten.key_flatten({foo: 'bar'}, symbolize: true)).to eq({foo: 'bar'})
-        expect(KeyFlatten.key_flatten({foo: {bar: 'baz'}}, symbolize: true)).to eq({:'foo.bar' => 'baz'})
+        expect(KeyFlatten.key_flatten({foo: 'bar'}, symbolize_keys: true)).to eq({foo: 'bar'})
+        expect(KeyFlatten.key_flatten({foo: {bar: 'baz'}}, symbolize_keys: true)).to eq({:'foo.bar' => 'baz'})
       end
     end
 


### PR DESCRIPTION
I think it's more natural.